### PR TITLE
Fix persistent login

### DIFF
--- a/www/include/lib_login.php
+++ b/www/include/lib_login.php
@@ -88,7 +88,7 @@
 
 	function login_do_login(&$user, $redir=''){
 
-		$expires = ($GLOBALS['cfg']['enable_feature_persistent_login']) ? time() * 2 : 0;
+		$expires = ($GLOBALS['cfg']['enable_feature_persistent_login']) ? strtotime('now +2 years') : 0;
 
 		$auth_cookie = login_generate_auth_cookie($user);
 		login_set_cookie($GLOBALS['cfg']['auth_cookie_name'], $auth_cookie, $expires);


### PR DESCRIPTION
Persistent login doesn't seem to work with time() \* 2, I think due to 2^32 overflow (if I had to guess). Setting it for 2 years in the future seems to be sufficiently persistent.
