### PR TITLE
setcookie with a domain of 'localhost' is unsupported

### DIFF
--- a/www/include/lib_login.php
+++ b/www/include/lib_login.php
@@ -119,7 +119,7 @@
 	#################################################################
 
 	function login_set_cookie($name, $value, $expire=0, $path='/'){
-		$domain = ($GLOBALS['cfg']['environment'] == 'localhost') ? false : $GLOBALS['cfg']['auth_cookie_domain'];
+		$domain = ($GLOBALS['cfg']['auth_cookie_domain'] == 'localhost') ? false : $GLOBALS['cfg']['auth_cookie_domain'];
 		$securify = (($GLOBALS['cfg']['auth_cookie_require_https']) && (isset($_SERVER['HTTPS'])) && ($_SERVER['HTTPS'] == 'on')) ? 1 : 0;
 		$res = setcookie($name, $value, $expire, $path, $domain, $securify);
 	}


### PR DESCRIPTION
by default flamework mysteriously fails to set cookies when running locally
this fixes it by not ever attempting to set localhost as the domain

alternate approach would be to set cfg["environment"] to localhost vs dev by default, but that might have down stream impact