### PR TITLE
Docker support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+*.sh text eol=lf
 * text=auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get install -y make
 #RUN pecl install xdebug
 #RUN echo "zend_extension=/usr/lib/php5/20090626+lfs/xdebug.so" > /etc/php5/conf.d/xdebug.ini
 
+VOLUME ["/mnt/flamework"]
+
 EXPOSE 80
 EXPOSE 443
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,6 @@ RUN chmod 755 www/templates_c
 RUN cp www/include/config.php.example www/include/config.php
 RUN cat tests/travis/config.php >> www/include/config.php
 
-RUN /etc/init.d/mysql start && \
-    mysql -e 'CREATE DATABASE flamework;' && \
-    mysql -Dflamework < schema/db_main.schema
-
 #RUN apt-get install -y php-pear
 #RUN pear channel-discover pear.phpunit.de
 #RUN pear install phpunit/PHP_CodeCoverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:14.04
+
+COPY . /vagrant
+
+WORKDIR /vagrant
+
+ENTRYPOINT [ "/bin/bash", "tests/vagrant/init.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,12 @@ RUN php5enmod mcrypt && \
 # This needs to be a volume mount so code can be edited and loaded live
 # but we also need to be able to set up a default config
 # TODO: Different config when docker vs travis?
-# TODO: Looks like we need a new VirtualHost apache config that sets the
-# right Directory AllowOverride and other configs. Or how to do another
-# approach for that?
 COPY . /mnt/flamework
 WORKDIR /mnt/flamework
+
+RUN ln -fs /mnt/flamework/tests/docker/001-flamework.conf /etc/apache2/sites-available/
+RUN a2ensite 001-flamework
+RUN a2dissite 000-default
 
 RUN rm -rf /var/www/html
 RUN ln -fs /mnt/flamework/www /var/www/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN ln -fs /mnt/flamework/www /var/www/html
 # Allow mounting of source code from external to the container
 VOLUME ["/mnt/flamework"]
 
+# Optional persistence of the mysql data
+VOLUME ["/var/lib/mysql"]
+
 # Listen on the HTTP and HTTPS ports
 EXPOSE 80
 EXPOSE 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,16 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get autoremove && \
     apt-get clean && apt-get autoclean
 
-RUN php5enmod mcrypt
+RUN php5enmod mcrypt && \
+    a2enmod rewrite
 
+# TODO: This whole section needs we-work. For example:
+# This needs to be a volume mount so code can be edited and loaded live
+# but we also need to be able to set up a default config
+# TODO: Different config when docker vs travis?
+# TODO: Looks like we need a new VirtualHost apache config that sets the
+# right Directory AllowOverride and other configs. Or how to do another
+# approach for that?
 COPY . /mnt/flamework
 WORKDIR /mnt/flamework
 
@@ -20,11 +28,13 @@ RUN chmod 755 www/templates_c
 RUN cp www/include/config.php.example www/include/config.php
 RUN cat tests/travis/config.php >> www/include/config.php
 
+# TODO: PHPUnit via Pear is dead. Also, conditionally install only when running tests?
 #RUN apt-get install -y php-pear
 #RUN pear channel-discover pear.phpunit.de
 #RUN pear install phpunit/PHP_CodeCoverage
 
 RUN apt-get install -y make
+# TODO: Only install when running tests?
 #RUN pecl install xdebug
 #RUN echo "zend_extension=/usr/lib/php5/20090626+lfs/xdebug.so" > /etc/php5/conf.d/xdebug.ini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get autoremove && \
     apt-get clean && apt-get autoclean
 
-# Turn on the mcrypt php module and the rewrite apache module
+# Turn on the mcrypt php module and the rewrite\ssl apache modules
 RUN php5enmod mcrypt && \
-    a2enmod rewrite
+    a2enmod rewrite && \
+    a2enmod ssl
+
+# TODO: Proper ssl certs via letsencrypt or something
 
 # Configure our path for where we'll serve source-code from
 WORKDIR /mnt/flamework

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,38 @@
 FROM ubuntu:14.04
 
-COPY . /vagrant
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y php5-cli git php5-mcrypt php5-curl apache2 libapache2-mod-php5 mysql-server php5-mysql memcached php5-memcache php5-mcrypt && \
+    apt-get autoremove && \
+    apt-get clean && apt-get autoclean
 
-WORKDIR /vagrant
+RUN php5enmod mcrypt
 
-ENTRYPOINT [ "/bin/bash", "tests/vagrant/init.sh" ]
+COPY . /mnt/flamework
+WORKDIR /mnt/flamework
+
+RUN rm -rf /var/www/html
+RUN ln -fs /mnt/flamework/www /var/www/html
+
+RUN chown www-data www/templates_c
+RUN chmod 755 www/templates_c
+RUN cp www/include/config.php.example www/include/config.php
+RUN cat tests/travis/config.php >> www/include/config.php
+
+RUN /etc/init.d/mysql start && \
+    mysql -e 'CREATE DATABASE flamework;' && \
+    mysql -Dflamework < schema/db_main.schema
+
+#RUN apt-get install -y php-pear
+#RUN pear channel-discover pear.phpunit.de
+#RUN pear install phpunit/PHP_CodeCoverage
+
+RUN apt-get install -y make
+#RUN pecl install xdebug
+#RUN echo "zend_extension=/usr/lib/php5/20090626+lfs/xdebug.so" > /etc/php5/conf.d/xdebug.ini
+
+EXPOSE 80
+EXPOSE 443
+
+ENTRYPOINT [ "/bin/bash", "tests/docker/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,36 +12,22 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 RUN php5enmod mcrypt && \
     a2enmod rewrite
 
-# Configure our paths for where we'll serve source-code from
-# TODO: This whole section needs we-work. For example:
-# This needs to be a volume mount so code can be edited and loaded live
-# but we also need to be able to set up a default config
-# TODO: Different config when docker vs travis?
-COPY . /mnt/flamework
+# Configure our path for where we'll serve source-code from
 WORKDIR /mnt/flamework
-
-RUN ln -fs /mnt/flamework/tests/docker/001-flamework.conf /etc/apache2/sites-available/
+COPY tests/docker/001-flamework.conf /etc/apache2/sites-available/
 RUN a2ensite 001-flamework
 RUN a2dissite 000-default
 
 RUN rm -rf /var/www/html
 RUN ln -fs /mnt/flamework/www /var/www/html
 
-# Templates need to be writable by the web server
-RUN chown www-data www/templates_c
-RUN chmod 755 www/templates_c
-
-# Put a config that we know will work in place
-RUN cp www/include/config.php.example www/include/config.php
-RUN cat tests/travis/config.php >> www/include/config.php
-
 # TODO: PHPUnit via Pear is dead. Also, conditionally install only when running tests?
 #RUN apt-get install -y php-pear
 #RUN pear channel-discover pear.phpunit.de
 #RUN pear install phpunit/PHP_CodeCoverage
 
-RUN apt-get install -y make
 # TODO: Only install when running tests?
+#RUN apt-get install -y make
 #RUN pecl install xdebug
 #RUN echo "zend_extension=/usr/lib/php5/20090626+lfs/xdebug.so" > /etc/php5/conf.d/xdebug.ini
 
@@ -52,5 +38,6 @@ VOLUME ["/mnt/flamework"]
 EXPOSE 80
 EXPOSE 443
 
-# When the container is run, this script will start mysql and apache
+# When the container is run, this script will start mysql and apache,
+# and put a sample config in place if necessary
 ENTRYPOINT [ "/bin/bash", "tests/docker/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:14.04
 
+# Install the packages we need
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get upgrade -y && \
@@ -7,9 +8,11 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get autoremove && \
     apt-get clean && apt-get autoclean
 
+# Turn on the mcrypt php module and the rewrite apache module
 RUN php5enmod mcrypt && \
     a2enmod rewrite
 
+# Configure our paths for where we'll serve source-code from
 # TODO: This whole section needs we-work. For example:
 # This needs to be a volume mount so code can be edited and loaded live
 # but we also need to be able to set up a default config
@@ -24,8 +27,11 @@ RUN a2dissite 000-default
 RUN rm -rf /var/www/html
 RUN ln -fs /mnt/flamework/www /var/www/html
 
+# Templates need to be writable by the web server
 RUN chown www-data www/templates_c
 RUN chmod 755 www/templates_c
+
+# Put a config that we know will work in place
 RUN cp www/include/config.php.example www/include/config.php
 RUN cat tests/travis/config.php >> www/include/config.php
 
@@ -39,9 +45,12 @@ RUN apt-get install -y make
 #RUN pecl install xdebug
 #RUN echo "zend_extension=/usr/lib/php5/20090626+lfs/xdebug.so" > /etc/php5/conf.d/xdebug.ini
 
+# Allow mounting of source code from external to the container
 VOLUME ["/mnt/flamework"]
 
+# Listen on the HTTP and HTTPS ports
 EXPOSE 80
 EXPOSE 443
 
+# When the container is run, this script will start mysql and apache
 ENTRYPOINT [ "/bin/bash", "tests/docker/entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,4 @@ cover:
 
 docker:
 	docker build -t flamework .
-	docker run -ti -p80\:8081 -p443\:4331 --name=flamework --rm flamework
+	docker run -ti -p80\:8081 -p443\:4331 -v ~/dev/flamework\:/mnt/flamework --name=flamework --rm flamework

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,7 @@ cover:
 	rm -rf ./coverage
 	-make test
 	php -q ./tests/coverage.php
+
+docker:
+	docker build -t flamework .
+	docker run -ti -p80\:8081 -p443\:4331 --name=flamework --rm flamework

--- a/README.md
+++ b/README.md
@@ -99,3 +99,20 @@ If you don't want to mess with your local development environment, you can run t
     vagrant ssh
     cd /vagrant
     make test
+
+## Docker
+
+Similarly, Docker is an option for both local development and test running, but is not suitable for production use (really, REALLY don't use it that way). To build and run:
+
+    docker build -t flamework .
+    docker run -ti -p80:8081 -p443:4331 --name=flamework --rm flamework
+
+Your local flamework copy should now be listening on ports `8081` and `4331` Docker randomly chose. Use `docker ps` to see them. To run tests, you can do:
+
+    docker exec -ti flamework make test
+
+And to tail the error logs:
+
+    docker exec -ti flamework tail -F /var/log/apache2/error.log
+
+When killing the container using either `CTRL+C` or `docker stop flamework`, the container will be removed and all data will be reset next run. This is useful for running tests.

--- a/README.md
+++ b/README.md
@@ -102,12 +102,14 @@ If you don't want to mess with your local development environment, you can run t
 
 ## Docker
 
-Similarly, Docker is an option for both local development and test running, but is not suitable for production use (really, REALLY don't use it that way). To build and run:
+Similarly, Docker is an option for both local development and test running, but is not suitable for production use (really, REALLY don't use it for prod -- we (intentionally) do not have this configured securely). To build and run:
 
     docker build -t flamework .
     docker run -ti -p80:8081 -p443:4331 --name=flamework --rm flamework
 
-Your local flamework copy should now be listening on ports `8081` and `4331`. Use `docker ps` to verify them. Once the container is running, to run tests you can do:
+Your local flamework copy should now be listening on ports `8081` and `4331`. Use `docker ps` to verify them. You'll need to edit <code>include/config.php</code> as usual.
+
+Once the container is running, to run tests you can do:
 
     docker exec -ti flamework make test
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Similarly, Docker is an option for both local development and test running, but 
     docker build -t flamework .
     docker run -ti -p80:8081 -p443:4331 -v ~/dev/flamework:/mnt/flamework --name=flamework --rm flamework
 
-Your local flamework copy should now be listening on ports `8081` and `4331`. Use `docker ps` to verify them. You'll need to edit <code>include/config.php</code> as usual.
+Your local flamework copy should now be listening on ports `8081` and `4331`. Use `docker ps` to verify them. You'll need to edit <code>include/config.php</code> as usual. Since you mounted your local dev flamework directory into the container, any code changes you make should be reflected immediately.
 
 Once the container is running, to run tests you can do:
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If you don't want to mess with your local development environment, you can run t
 Similarly, Docker is an option for both local development and test running, but is not suitable for production use (really, REALLY don't use it for prod -- we (intentionally) do not have this configured securely). To build and run:
 
     docker build -t flamework .
-    docker run -ti -p80:8081 -p443:4331 --name=flamework --rm flamework
+    docker run -ti -p80:8081 -p443:4331 -v ~/dev/flamework:/mnt/flamework --name=flamework --rm flamework
 
 Your local flamework copy should now be listening on ports `8081` and `4331`. Use `docker ps` to verify them. You'll need to edit <code>include/config.php</code> as usual.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Similarly, Docker is an option for both local development and test running, but 
     docker build -t flamework .
     docker run -ti -p80:8081 -p443:4331 --name=flamework --rm flamework
 
-Your local flamework copy should now be listening on ports `8081` and `4331` Docker randomly chose. Use `docker ps` to see them. To run tests, you can do:
+Your local flamework copy should now be listening on ports `8081` and `4331`. Use `docker ps` to verify them. Once the container is running, to run tests you can do:
 
     docker exec -ti flamework make test
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ And some random odds and ends:
 
 ## Tests
 
-If you have `make` and and recent `perl` installed (you almost certainly do), you can run the tests using:
+If you have `make` and and recent `perl` installed (you almost certainly do, or if not see [Vagrant](#vagrant) and [Docker](#docker) sections below), you can run the tests using:
 
     make test
 

--- a/tests/02_http_codes.t
+++ b/tests/02_http_codes.t
@@ -91,7 +91,7 @@
 
 	foreach ($codes as $row){
 
-		$ret = http_get("http://www.iamcal.com/misc/test/code.php?code={$row[0]}&msg=".urlencode($row[1]));
+		$ret = http_get("https://www.iamcal.com/misc/test/code.php?code={$row[0]}&msg=".urlencode($row[1]));
 
 		$test = "{$row[0]}: {$row[1]}";
 		if (isset($row[2])) $test .= " {$row[2]}";

--- a/tests/02_http_methods.t
+++ b/tests/02_http_methods.t
@@ -25,17 +25,17 @@
 	}
 
 
-	$ret = http_get("http://www.iamcal.com/misc/test/method.php");
+	$ret = http_get("https://www.iamcal.com/misc/test/method.php");
 	test_http_method($ret, 'GET', 0, 0);
 
-	$ret = http_get("http://www.iamcal.com/misc/test/method.php?a=1&b=2");
+	$ret = http_get("https://www.iamcal.com/misc/test/method.php?a=1&b=2");
 	test_http_method($ret, 'GET', 2, 0);
 
-	$ret = http_head("http://www.iamcal.com/misc/test/method.php");
+	$ret = http_head("https://www.iamcal.com/misc/test/method.php");
 	test_http_method($ret, 'HEAD', 0, 0);
 
-	$ret = http_post("http://www.iamcal.com/misc/test/method.php", array());
+	$ret = http_post("https://www.iamcal.com/misc/test/method.php", array());
 	test_http_method($ret, 'POST', 0, 0);
 
-	$ret = http_post("http://www.iamcal.com/misc/test/method.php?a=1", array('b' => 2, 'c' => 3));
+	$ret = http_post("https://www.iamcal.com/misc/test/method.php?a=1", array('b' => 2, 'c' => 3));
 	test_http_method($ret, 'POST', 1, 2);

--- a/tests/docker/001-flamework.conf
+++ b/tests/docker/001-flamework.conf
@@ -1,0 +1,45 @@
+<VirtualHost *:80>
+        DocumentRoot /var/www/html
+
+        <Directory /var/www/html>
+                Options +Indexes +FollowSymLinks -MultiViews
+                AllowOverride All
+                Order allow,deny
+                allow from all
+                require all granted
+        </Directory>
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+
+        # Possible values include: debug, info, notice, warn, error, crit,
+        # alert, emerg.
+        LogLevel warn
+
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        RewriteEngine on
+        #RewriteLog ${APACHE_LOG_DIR}/rewrite.log
+        #RewriteLogLevel 3
+
+        DirectoryIndex index.php
+</VirtualHost>
+
+<VirtualHost *:443>
+        DocumentRoot /var/www/html
+
+        <Directory /var/www/html>
+                Options +Indexes -MultiViews
+                AllowOverride All
+                Order allow,deny
+                allow from all
+                require all granted
+        </Directory>
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        LogLevel warn
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        RewriteEngine on
+        
+        DirectoryIndex index.php
+</VirtualHost>

--- a/tests/docker/001-flamework.conf
+++ b/tests/docker/001-flamework.conf
@@ -40,6 +40,10 @@
         CustomLog ${APACHE_LOG_DIR}/access.log combined
 
         RewriteEngine on
-        
+
         DirectoryIndex index.php
+
+        SSLEngine on
+        SSLCertificateFile      /etc/ssl/certs/ssl-cert-snakeoil.pem
+        SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
 </VirtualHost>

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+/etc/init.d/mysql start
+/etc/init.d/memcached start
+
+exec apachectl -D FOREGROUND

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -1,11 +1,26 @@
 #!/usr/bin/env bash
 
+# We want to halt on errors and also print out what we're doing
 set -eux
 
+# Start memcached
 /etc/init.d/memcached start
 
+# Start mysql and create the database if it doesn't exist
 /etc/init.d/mysql start
 mysql -e 'CREATE DATABASE IF NOT EXISTS flamework;'
 mysql -Dflamework < schema/db_main.schema
 
+# Put the example configuration in place if it doesn't exist
+cd /mnt/flamework
+if [[ ! -e www/include/config.php ]]; then
+    cp www/include/config.php.example www/include/config.php
+    perl -i -pe "s/'pass'\t=> 'root',/'pass'\t=> '',/g" www/include/config.php
+fi
+
+# Templates need to be writable by the web server
+chown www-data www/templates_c
+chmod 755 www/templates_c
+
+# Start apache in the foreground so that the container stays running
 exec apachectl -D FOREGROUND

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-/etc/init.d/mysql start
 /etc/init.d/memcached start
+
+/etc/init.d/mysql start
+mysql -e 'CREATE DATABASE IF NOT EXISTS flamework;'
+mysql -Dflamework < schema/db_main.schema
 
 exec apachectl -D FOREGROUND

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eux
+
 /etc/init.d/memcached start
 
 /etc/init.d/mysql start


### PR DESCRIPTION
# Description
Adds Docker support. Useful for local development and running tests, but not (yet) for production serving. Tested on MacOS and Windows.

# Rationale
12+ years on, Flamework remains the best option for quickly doing PHP projects. However, there's a lot of work to be done to bring this codebase up to modern PHP syntax and cloud hosting options. Before I started working on those I wanted a checkpoint for running tests that's not Vagrant (since Vagrant doesn't run natively on Apple silicon). Once the upgrades are done, the goal would be to make the docker container deployable by stripping down to just the PHP runtime (and Flamework code changes to support that).

# The Now
This is mostly a port of the existing Vagrant scripts into Docker. It installs PHP 5.5.9, Apache 2.4.7, memcached 1.4.14, and MySQL 5.5.62. It looks like the version most-recently tested was PHP 5.4, but 5.5 was easy to find and runs cleanly.

All the daemons are all started in a single container, and basic SSL is configured. Enough config is put in place to connect to the database, but secrets need to be set to actually do login and set cookies. The SSL config is so ancient that modern browsers reject it outright and don't allow you to override, thus no auto-HTTPS upgrades are done.

If no `flamework` database is in place at container runtime, it is created. DB persistence is optional with Docker volumes, but otherwise wiped between runs to make test runs cleaner. Code is mounted from a volume so that live code editing can be supported.

## Reasons not to use this in production (yet)
* PHP is very outdated and has security vulnerabilities
* The underlying OS is very outdated and has security vulnerabilities
* This starts `memcached`, `mysql`, and `apache2` in a single container (containers shouldn't run more than one daemon at a time)
* No real effort is made to make this anything other than ephemeral
* SSL is completely broken

# The Future
Immediate work will be around adding more tests to exercise the existing code. Then PHP will be brought up to the most modern versions, which will involve at the very least removing `mcrypt` and upgrading Smarty (this is where more tests will be handy).

## Additional goals in my head:
* SSL via letsencrypt?
* SQLite (for tests or maybe also as the primary supported DB engine). Would need a `ticketd` replacement solution.
* Github Actions to replace Travis
* Code coverage options
* Tests away from needing Perl and prove
* There's some good stuff in #26 we can bring in here

# Other changes
* Tests were updated because of iamcal.com changes
* `make docker` target added
* `README` notes on using the Docker image
* `.gitattributes` set to `eol=lf` for shell scripts, since WSL (and therefore Docker on Windows) required it